### PR TITLE
Fix .NET Framework 4.8 internal structure marshaling.

### DIFF
--- a/lib/include/cpuinfo_x86_port.h
+++ b/lib/include/cpuinfo_x86_port.h
@@ -19,7 +19,7 @@
 #include "cpuinfo_x86.h"
 
 CPU_FEATURES_DOTNET_DLL_EXPORT void GetX86InfoPort(char brand_string[49], char vendor[13], int *model, int *stepping,
-                                                   int *family, int *features_raw1, int *features_raw2);
+                                                   int *family, X86Features *features);
 
 CPU_FEATURES_DOTNET_DLL_EXPORT void GetX86CacheInfoPort(int *size, CacheLevelInfo *levels);
 

--- a/lib/include/cpuinfo_x86_port.h
+++ b/lib/include/cpuinfo_x86_port.h
@@ -21,7 +21,7 @@
 CPU_FEATURES_DOTNET_DLL_EXPORT void GetX86InfoPort(char brand_string[49], char vendor[13], int *model, int *stepping,
                                                    int *family, int *features_raw1, int *features_raw2);
 
-CPU_FEATURES_DOTNET_DLL_EXPORT CacheInfo GetX86CacheInfoPort(void);
+CPU_FEATURES_DOTNET_DLL_EXPORT void GetX86CacheInfoPort(int *size, CacheLevelInfo *levels);
 
 CPU_FEATURES_DOTNET_DLL_EXPORT X86Microarchitecture GetX86MicroarchitecturePort(const X86Info *info);
 

--- a/lib/include/cpuinfo_x86_port.h
+++ b/lib/include/cpuinfo_x86_port.h
@@ -18,7 +18,8 @@
 #include "cpu_features_port_macros.h"
 #include "cpuinfo_x86.h"
 
-CPU_FEATURES_DOTNET_DLL_EXPORT X86Info GetX86InfoPort(void);
+CPU_FEATURES_DOTNET_DLL_EXPORT void GetX86InfoPort(char brand_string[49], char vendor[13], int *model, int *stepping,
+                                                   int *family, int *features_raw1, int *features_raw2);
 
 CPU_FEATURES_DOTNET_DLL_EXPORT CacheInfo GetX86CacheInfoPort(void);
 

--- a/lib/src/impl_cpuinfo_x86_port.c
+++ b/lib/src/impl_cpuinfo_x86_port.c
@@ -42,7 +42,9 @@ void GetX86InfoPort(char brand_string[49], char vendor[13], int *model, int *ste
     vendor[12] = '\0';
 }
 
-CacheInfo GetX86CacheInfoPort(void) {
-    return GetX86CacheInfo();
+void GetX86CacheInfoPort(int *size, CacheLevelInfo *levels) {
+    CacheInfo cacheInfo = GetX86CacheInfo();
+    *size = cacheInfo.size;
+    Copy((char *) levels, (const char *) cacheInfo.levels, sizeof(CacheLevelInfo) * 10);
 }
 #endif  // CPU_FEATURES_ARCH_X86

--- a/lib/src/impl_cpuinfo_x86_port.c
+++ b/lib/src/impl_cpuinfo_x86_port.c
@@ -16,6 +16,7 @@
 
 #if defined(CPU_FEATURES_ARCH_X86)
 #include "cpuinfo_x86_port.h"
+#include "copy.inl"
 
 X86Microarchitecture GetX86MicroarchitecturePort(const X86Info *info) {
     return GetX86Microarchitecture(info);
@@ -25,8 +26,20 @@ void FillX86BrandStringPort(char *brand_string) {
     FillX86BrandString(brand_string);
 }
 
-X86Info GetX86InfoPort(void) {
-    return GetX86Info();
+void GetX86InfoPort(char brand_string[49], char vendor[13], int *model, int *stepping, int *family,
+                    int *features_raw1,
+                    int *features_raw2) {
+    X86Info info = GetX86Info();
+    *model = info.model;
+    *stepping = info.stepping;
+    *family = info.family;
+    int *features = (int *) &info;
+    *features_raw1 = features[0];
+    *features_raw2 = features[1];
+    Copy(brand_string, info.brand_string, 48);
+    Copy(vendor, info.vendor, 12);
+    brand_string[48] = '\0';
+    vendor[12] = '\0';
 }
 
 CacheInfo GetX86CacheInfoPort(void) {

--- a/lib/src/impl_cpuinfo_x86_port.c
+++ b/lib/src/impl_cpuinfo_x86_port.c
@@ -26,16 +26,13 @@ void FillX86BrandStringPort(char *brand_string) {
     FillX86BrandString(brand_string);
 }
 
-void GetX86InfoPort(char brand_string[49], char vendor[13], int *model, int *stepping, int *family,
-                    int *features_raw1,
-                    int *features_raw2) {
+void GetX86InfoPort(char brand_string[49], char vendor[13], int *model, int *stepping,
+                    int *family, X86Features *features) {
     X86Info info = GetX86Info();
     *model = info.model;
     *stepping = info.stepping;
     *family = info.family;
-    int *features = (int *) &info;
-    *features_raw1 = features[0];
-    *features_raw2 = features[1];
+    *features = info.features;
     Copy(brand_string, info.brand_string, 48);
     Copy(vendor, info.vendor, 12);
     brand_string[48] = '\0';

--- a/src/CpuFeaturesDotNet/CacheInfo.cs
+++ b/src/CpuFeaturesDotNet/CacheInfo.cs
@@ -38,14 +38,13 @@ namespace CpuFeaturesDotNet
         private static unsafe CacheInfo _GetX86CacheInfo()
         {
             int size;
-            var ptrSize = &size;
             var cacheLevelInfo = new CacheLevelInfo[10];
             fixed (CacheLevelInfo* ptrLevels = cacheLevelInfo)
             {
-                CacheInfoNative.__GetX86CacheInfo(ptrSize, ptrLevels);
+                CacheInfoNative.__GetX86CacheInfo(&size, ptrLevels);
             }
 
-            return new CacheInfo(*ptrSize, cacheLevelInfo);
+            return new CacheInfo(size, cacheLevelInfo);
         }
 #else
         /// <summary>

--- a/src/CpuFeaturesDotNet/CacheInfo.cs
+++ b/src/CpuFeaturesDotNet/CacheInfo.cs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Runtime.InteropServices;
-
 namespace CpuFeaturesDotNet
 {
-    [StructLayout(LayoutKind.Sequential)]
     public readonly struct CacheInfo
     {
         public readonly int Size;

--- a/src/CpuFeaturesDotNet/CacheInfo.cs
+++ b/src/CpuFeaturesDotNet/CacheInfo.cs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Runtime.InteropServices;
+
 namespace CpuFeaturesDotNet
 {
+    [StructLayout(LayoutKind.Sequential)]
     public readonly struct CacheInfo
     {
         public readonly int Size;

--- a/src/CpuFeaturesDotNet/CacheInfoNative.cs
+++ b/src/CpuFeaturesDotNet/CacheInfoNative.cs
@@ -19,6 +19,6 @@ namespace CpuFeaturesDotNet
     internal static class CacheInfoNative
     {
         [DllImport(Library.NATIVE_LIBRARY, EntryPoint = "GetX86CacheInfoPort")]
-        public static extern CacheInfo _GetX86CacheInfoPort();
+        public static extern unsafe void __GetX86CacheInfo(int* size, CacheLevelInfo* levels);
     }
 }

--- a/src/CpuFeaturesDotNet/X86/X86Features.cs
+++ b/src/CpuFeaturesDotNet/X86/X86Features.cs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Runtime.InteropServices;
-
 namespace CpuFeaturesDotNet.X86
 {
-    [StructLayout(LayoutKind.Sequential)]
     public readonly struct X86Features
     {
         private readonly int featuresRaw1;

--- a/src/CpuFeaturesDotNet/X86/X86Features.cs
+++ b/src/CpuFeaturesDotNet/X86/X86Features.cs
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Runtime.InteropServices;
+
 namespace CpuFeaturesDotNet.X86
 {
+    [StructLayout(LayoutKind.Sequential)]
     public readonly struct X86Features
     {
         private readonly int featuresRaw1;

--- a/src/CpuFeaturesDotNet/X86/X86Info.cs
+++ b/src/CpuFeaturesDotNet/X86/X86Info.cs
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace CpuFeaturesDotNet.X86
 {
+    [StructLayout(LayoutKind.Sequential)]
     public readonly struct X86Info
     {
         public readonly X86Features Features;
@@ -45,12 +47,9 @@ namespace CpuFeaturesDotNet.X86
         {
             var brandString = new System.Text.StringBuilder(48);
             var vendor = new System.Text.StringBuilder(12);
-            int model, stepping, family, featuresRaw1, featuresRaw2;
-
-            X86InfoNative.__GetX86Info(brandString, vendor, &model, &stepping, &family,
-                &featuresRaw1, &featuresRaw2);
-
-            var features = new X86Features(featuresRaw1, featuresRaw2);
+            int model, stepping, family;
+            X86Features features;
+            X86InfoNative.__GetX86Info(brandString, vendor, &model, &stepping, &family, &features);
             return new X86Info(features, family, model, stepping, vendor.ToString(),
                 brandString.ToString());
         }

--- a/src/CpuFeaturesDotNet/X86/X86Info.cs
+++ b/src/CpuFeaturesDotNet/X86/X86Info.cs
@@ -13,11 +13,9 @@
 // limitations under the License.
 
 using System;
-using System.Runtime.InteropServices;
 
 namespace CpuFeaturesDotNet.X86
 {
-    [StructLayout(LayoutKind.Sequential)]
     public readonly struct X86Info
     {
         public readonly X86Features Features;

--- a/src/CpuFeaturesDotNet/X86/X86Info.cs
+++ b/src/CpuFeaturesDotNet/X86/X86Info.cs
@@ -48,17 +48,12 @@ namespace CpuFeaturesDotNet.X86
             var brandString = new System.Text.StringBuilder(48);
             var vendor = new System.Text.StringBuilder(12);
             int model, stepping, family, featuresRaw1, featuresRaw2;
-            var ptrModel = &model;
-            var ptrStepping = &stepping;
-            var ptrFamily = &family;
-            var ptrFeaturesRaw1 = &featuresRaw1;
-            var ptrFeaturesRaw2 = &featuresRaw2;
 
-            X86InfoNative.__GetX86Info(brandString, vendor, ptrModel, ptrStepping, ptrFamily,
-                ptrFeaturesRaw1, ptrFeaturesRaw2);
+            X86InfoNative.__GetX86Info(brandString, vendor, &model, &stepping, &family,
+                &featuresRaw1, &featuresRaw2);
 
-            var features = new X86Features(*ptrFeaturesRaw1, *ptrFeaturesRaw2);
-            return new X86Info(features, *ptrFamily, *ptrModel, *ptrStepping, vendor.ToString(),
+            var features = new X86Features(featuresRaw1, featuresRaw2);
+            return new X86Info(features, family, model, stepping, vendor.ToString(),
                 brandString.ToString());
         }
 

--- a/src/CpuFeaturesDotNet/X86/X86InfoNative.cs
+++ b/src/CpuFeaturesDotNet/X86/X86InfoNative.cs
@@ -21,7 +21,7 @@ namespace CpuFeaturesDotNet.X86
     {
         [DllImport(Library.NATIVE_LIBRARY, EntryPoint = "GetX86InfoPort")]
         public static extern unsafe void __GetX86Info(StringBuilder brandString, StringBuilder vendor, int* model,
-            int* stepping, int* family, int* features_raw1, int* features_raw2);
+            int* stepping, int* family, int* featuresRaw1, int* featuresRaw2);
 
         [DllImport(Library.NATIVE_LIBRARY, EntryPoint = "GetX86MicroarchitecturePort")]
         public static extern X86Microarchitecture _GetX86Microarchitecture(in X86Info info);

--- a/src/CpuFeaturesDotNet/X86/X86InfoNative.cs
+++ b/src/CpuFeaturesDotNet/X86/X86InfoNative.cs
@@ -20,7 +20,8 @@ namespace CpuFeaturesDotNet.X86
     internal static class X86InfoNative
     {
         [DllImport(Library.NATIVE_LIBRARY, EntryPoint = "GetX86InfoPort")]
-        public static extern X86Info _GetX86Info();
+        public static extern unsafe void __GetX86Info(StringBuilder brandString, StringBuilder vendor, int* model,
+            int* stepping, int* family, int* features_raw1, int* features_raw2);
 
         [DllImport(Library.NATIVE_LIBRARY, EntryPoint = "GetX86MicroarchitecturePort")]
         public static extern X86Microarchitecture _GetX86Microarchitecture(in X86Info info);

--- a/src/CpuFeaturesDotNet/X86/X86InfoNative.cs
+++ b/src/CpuFeaturesDotNet/X86/X86InfoNative.cs
@@ -21,7 +21,7 @@ namespace CpuFeaturesDotNet.X86
     {
         [DllImport(Library.NATIVE_LIBRARY, EntryPoint = "GetX86InfoPort")]
         public static extern unsafe void __GetX86Info(StringBuilder brandString, StringBuilder vendor, int* model,
-            int* stepping, int* family, int* featuresRaw1, int* featuresRaw2);
+            int* stepping, int* family, X86Features* features);
 
         [DllImport(Library.NATIVE_LIBRARY, EntryPoint = "GetX86MicroarchitecturePort")]
         public static extern X86Microarchitecture _GetX86Microarchitecture(in X86Info info);

--- a/tests/DllImportX86Tests.cs
+++ b/tests/DllImportX86Tests.cs
@@ -36,6 +36,12 @@ namespace CpuFeaturesDotNet.Testing
         }
 
         [FactX64]
+        public void DllImportX86_GetX86CacheInfo_Success()
+        {
+            CacheInfo.GetX86CacheInfo();
+        }
+
+        [FactX64]
         public void DllImportX86_GetX86BrandString_Success()
         {
             X86Info.GetX86BrandString();


### PR DESCRIPTION
Currently throwing a `MarshalDirectiveException` in the .NET Framework., in this PR I did unit testing for .NET Framework 4.8, seems to work
![image](https://user-images.githubusercontent.com/43444946/155046008-ce31cd38-9774-40f4-b3ec-9f537ce55366.png)

_Note: Before merging this change, we need to provide CI for the .NET Framework_ 