### PR TITLE
Update version to the .NET 6.0 LTS

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -67,8 +67,6 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            3.1.x
-            5.0.x
             6.0.x
 
       - name: Install Ninja
@@ -92,8 +90,5 @@ jobs:
       - name: Create build
         run: ${{ runner.os!='Windows'&&'sudo '||''}}dotnet build "src/CpuFeaturesDotNet" -c ${{ matrix.build-type }} --force
 
-      - name: Run Unit Tests for .Net Core 3.1
-        run: ${{ runner.os!='Windows'&&'sudo '||''}}dotnet test "tests" -c ${{ matrix.build-type }} -f netcoreapp3.1
-
-      - name: Run Unit Tests for .Net 5.0
-        run: ${{ runner.os!='Windows'&&'sudo '||''}}dotnet test "tests" -c ${{ matrix.build-type }} -f net5.0
+      - name: Run Unit Tests for .NET 6
+        run: ${{ runner.os!='Windows'&&'sudo '||''}}dotnet test "tests" -c ${{ matrix.build-type }} -f net6.0

--- a/samples/CpuFeaturesDotNet.Samples/CpuFeaturesDotNet.Samples.csproj
+++ b/samples/CpuFeaturesDotNet.Samples/CpuFeaturesDotNet.Samples.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tests/CpuFeaturesDotNet.Testing.csproj
+++ b/tests/CpuFeaturesDotNet.Testing.csproj
@@ -6,7 +6,7 @@
 
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
-        <TargetFrameworks>net5.0;netcoreapp3.1;net48</TargetFrameworks>
+        <TargetFrameworks>net6.0;net48</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
.NET Core 3.1 and .NET 5 is out of support, so in this PR updates version of github actions and target frameworks to `.net 6.0`

ref:
https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

